### PR TITLE
Add simple audio visualization example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# Test
+# Audio Visualization
+
+Open `index.html` in a browser and click **Start** to allow microphone access and view the audio-reactive bar visualization.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Audio Visualizer</title>
+<style>
+  body { margin: 0; background: #111; color: white; text-align: center; }
+  canvas { width: 100%; height: 100vh; display: block; }
+  #start { position: absolute; top: 20px; left: 20px; }
+</style>
+</head>
+<body>
+<button id="start">Start</button>
+<canvas id="canvas"></canvas>
+<script>
+const startButton = document.getElementById('start');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+function drawBars(data) {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const barWidth = canvas.width / data.length;
+  for (let i = 0; i < data.length; i++) {
+    const barHeight = data[i];
+    const x = i * barWidth;
+    const y = canvas.height - barHeight;
+    ctx.fillStyle = 'lime';
+    ctx.fillRect(x, y, barWidth, barHeight);
+  }
+}
+
+startButton.onclick = async () => {
+  startButton.remove();
+  const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+  const source = audioCtx.createMediaStreamSource(stream);
+  const analyser = audioCtx.createAnalyser();
+  analyser.fftSize = 256;
+  source.connect(analyser);
+  const bufferLength = analyser.frequencyBinCount;
+  const dataArray = new Uint8Array(bufferLength);
+  function animate() {
+    requestAnimationFrame(animate);
+    analyser.getByteFrequencyData(dataArray);
+    drawBars(dataArray);
+  }
+  animate();
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` demonstrating bar visualization driven by microphone audio
- document how to run the example

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6898d377fc948323966e5ec488bc8178